### PR TITLE
Scaling variables

### DIFF
--- a/examples/grid4d_test.py
+++ b/examples/grid4d_test.py
@@ -1,0 +1,186 @@
+# %%
+import time
+import warnings
+import numpy as np
+from scipy.ndimage import gaussian_filter
+import pandas as pd
+from traffic.data import opensky
+from openap import contrail, aero
+from openap_top import top
+from fastmeteo.source import ArcoEra5
+import math
+from traffic.core import Flight
+
+def objective(x, u, dt, **kwargs):
+    grid_cost = optimizer.obj_grid_cost(
+        x, u, dt, time_dependent=True, n_dim=4, **kwargs
+    )
+    fuel_cost = optimizer.obj_fuel(x, u, dt, **kwargs)
+    return grid_cost * 0.5 + fuel_cost * 0.5
+
+# %%
+warnings.filterwarnings("ignore")
+
+actype = "B738"
+start = "2023-01-05 09:48"
+stop = "2023-01-05 12:00"
+
+m0 = 0.85
+
+flight_0 = opensky.history(start, stop, callsign="RYR880W", return_flight=True)
+counts = flight_0.data['icao24'].value_counts()
+main_icao24 = counts.idxmax()
+flight_main = Flight(flight_0.data[flight_0.data['icao24'] == main_icao24].copy())
+t = flight_main.drop(["last_position", "onground"], axis=1).query("latitude.notnull()")
+
+era5 = ArcoEra5(local_store="/tmp/era5-zarr")
+# Enable wind
+origin_lat = t.data.latitude.iloc[0]
+origin_lon = t.data.longitude.iloc[0]
+destination_lat = t.data.latitude.iloc[-1]
+destination_lon = t.data.longitude.iloc[-1]
+
+latmin = math.ceil(min(origin_lat, destination_lat)) - 2
+latmax = math.ceil(max(origin_lat, destination_lat)) + 2
+lonmin = math.ceil(min(origin_lon, destination_lon)) - 4
+lonmax = math.ceil(max(origin_lon, destination_lon)) + 4
+
+# creates numpy arrays
+latitudes = np.arange(latmin, latmax, 1)
+longitudes = np.arange(lonmin, lonmax, 1)
+altitudes = np.arange(1000, 46000, 1500)
+timestamps = pd.date_range(start, stop, freq="1H")
+
+latitudes, longitudes, altitudes, times = np.meshgrid(
+    latitudes, longitudes, altitudes, timestamps
+)
+
+grid = pd.DataFrame().assign(
+    latitude=latitudes.flatten(),
+    longitude=longitudes.flatten(),
+    altitude=altitudes.flatten(),
+    timestamp=times.flatten(),
+)
+
+meteo = era5.interpolate(grid)
+f = meteo.assign(
+    rhi=lambda d: contrail.relative_humidity(d.specific_humidity,
+                                             aero.pressure(d.altitude * aero.ft),
+                                             d.temperature, to="ice"),
+    crit_temp=lambda d: contrail.critical_temperature_water(aero.pressure(d.altitude * aero.ft)),
+    sac=lambda d: d.temperature < d.crit_temp,
+    issr=lambda d: d.rhi > 1,
+    persistent=lambda d: d.sac & d.issr
+)
+
+# Base optimizer
+optimizer = top.CompleteFlight(
+    "A320",
+    (origin_lat, origin_lon),
+    (destination_lat, destination_lon),
+    m0,
+)
+# optimizer = top.Cruise(
+#     actype,
+#     (origin_lat, origin_lon),
+#     (destination_lat, destination_lon),
+#     m0,
+# )
+start = time.time()
+wind = (
+    meteo.rename(columns={"u_component_of_wind": "u", "v_component_of_wind": "v"})
+    .assign(ts=lambda x: (x.timestamp - x.timestamp.iloc[0]).dt.total_seconds())
+    .eval("h = altitude * 0.3048")
+)[["ts", "latitude", "longitude", "h", "u", "v"]]
+
+# Prepare contrail cost grid
+df_cost = (
+    f.assign(
+        height=lambda x: x.altitude * aero.ft,
+        cost=lambda x: x.persistent.astype(float),
+        ts=lambda x: (x.timestamp - x.timestamp.iloc[0]).dt.total_seconds(),
+    )
+    .sort_values(["ts", "height", "latitude", "longitude"])
+)
+
+cost = df_cost.cost.values.reshape(
+    df_cost.ts.nunique(),
+    df_cost.height.nunique(),
+    df_cost.latitude.nunique(),
+    df_cost.longitude.nunique(),
+)
+
+cost_ = gaussian_filter(cost, sigma=(0, 2, 2, 2), mode="nearest")
+df_cost = df_cost.assign(cost=cost_.flatten()).fillna(0)
+interpolant = top.tools.interpolant_from_dataframe(df_cost)
+
+# Baseline trajectories
+optimizer_fuel = optimizer.trajectory(objective="fuel", interpolant=interpolant, scaling = True)
+
+# Evaluate components post-solution
+grid_cost_val = float(np.sum(optimizer_fuel["grid_cost"]))
+fuel_cost_val = float(np.sum(optimizer_fuel["fuel_cost"]))
+obj = optimizer.solver.stats()["iterations"]["obj"][-1]
+status = optimizer.solver.stats()['success']
+
+print(
+    f"Grid Cost: {grid_cost_val:.2f} | Fuel Cost: {fuel_cost_val:.2f} | Objective: {obj:.2f} | Success:{status}")
+
+# For MultiPhase case
+# obj_cr = optimizer.get_solver_stats()["cruise"]["iterations"]["obj"][-1]
+# status_cr = optimizer.get_solver_stats()["cruise"]["success"]
+# obj_cl = optimizer.get_solver_stats()["climb"]["iterations"]["obj"][-1]
+# status_cl = optimizer.get_solver_stats()["climb"]["success"]
+# obj_de = optimizer.get_solver_stats()["descent"]["iterations"]["obj"][-1]
+# status_de = optimizer.get_solver_stats()["descent"]["success"]
+
+# print(
+#     f"Grid Cost: {grid_cost_val:.2f} | Fuel Cost: {fuel_cost_val:.2f} | Objective climb: {obj_cl:.2f} | Success climb:{status_cl} | Objective cruise: {obj_cr:.2f} | Success cruise:{status_cr} | Objective descent: {obj_de:.2f} | Success descent:{status_de} ")
+
+optimizer.enable_wind(wind)
+optimizer_wind = optimizer.trajectory(objective="fuel", initial_guess=optimizer_fuel, interpolant=interpolant, scaling=True)
+
+# Evaluate components post-solution
+grid_cost_val = float(np.sum(optimizer_wind["grid_cost"]))
+fuel_cost_val = float(np.sum(optimizer_wind["fuel_cost"]))
+
+obj = optimizer.solver.stats()["iterations"]["obj"][-1]
+status = optimizer.solver.stats()['success']
+
+print(
+    f"Grid Cost: {grid_cost_val:.2f} | Fuel Cost: {fuel_cost_val:.2f} | Objective: {obj:.2f} | Success:{status}")
+
+#For MultiPhase case
+# obj_cr = optimizer.get_solver_stats()["cruise"]["iterations"]["obj"][-1]
+# status_cr = optimizer.get_solver_stats()["cruise"]["success"]
+# obj_cl = optimizer.get_solver_stats()["climb"]["iterations"]["obj"][-1]
+# status_cl = optimizer.get_solver_stats()["climb"]["success"]
+# obj_de = optimizer.get_solver_stats()["descent"]["iterations"]["obj"][-1]
+# status_de = optimizer.get_solver_stats()["descent"]["success"]
+#
+# print(
+#     f"Grid Cost: {grid_cost_val:.2f} | Fuel Cost: {fuel_cost_val:.2f} | Objective climb: {obj_cl:.2f} | Success climb:{status_cl} | Objective cruise: {obj_cr:.2f} | Success cruise:{status_cr} | Objective descent: {obj_de:.2f} | Success descent:{status_de} ")
+
+
+optimizer_contrail = optimizer.trajectory(objective=objective, interpolant=interpolant,
+                                          initial_guess=optimizer_wind, scaling = True)
+
+# Evaluate components post-solution
+grid_cost_val = float(np.sum(optimizer_contrail["grid_cost"]))
+fuel_cost_val = float(np.sum(optimizer_contrail["fuel_cost"]))
+
+obj = optimizer.solver.stats()["iterations"]["obj"][-1]
+status = optimizer.solver.stats()['success']
+print(
+    f"Grid Cost: {grid_cost_val:.2f} | Fuel Cost: {fuel_cost_val:.2f} | Objective: {obj:.2f} | Success:{status}")
+
+# obj_cr = optimizer.get_solver_stats()["cruise"]["iterations"]["obj"][-1]
+# status_cr = optimizer.get_solver_stats()["cruise"]["success"]
+# obj_cl = optimizer.get_solver_stats()["climb"]["iterations"]["obj"][-1]
+# status_cl = optimizer.get_solver_stats()["climb"]["success"]
+# obj_de = optimizer.get_solver_stats()["descent"]["iterations"]["obj"][-1]
+# status_de = optimizer.get_solver_stats()["descent"]["success"]
+#
+# print(
+#     f"Grid Cost: {grid_cost_val:.2f} | Fuel Cost: {fuel_cost_val:.2f} | Objective climb: {obj_cl:.2f} | Success climb:{status_cl} | Objective cruise: {obj_cr:.2f} | Success cruise:{status_cr} | Objective descent: {obj_de:.2f} | Success descent:{status_de} ")
+print(f"\nOptimal trajectory was generated in {round(time.time() - start)} seconds.\n")

--- a/examples/quick_test.py
+++ b/examples/quick_test.py
@@ -14,15 +14,15 @@ origin = "EHAM"
 destination = "LGAV"
 m0 = 0.85
 
-optimizer = top.CompleteFlight(actype, origin, destination, m0)
+# optimizer = top.CompleteFlight(actype, origin, destination, m0)
 # optimizer = top.MultiPhase(actype, origin, destination, m0)
-# optimizer = top.Cruise(actype, origin, destination, m0)
+optimizer = top.Cruise(actype, origin, destination, m0)
 # optimizer = top.Climb(actype, origin, destination, m0)
 # optimizer = top.Descent(actype, origin, destination, m0)
 
 start = time.time()
 
-flight = optimizer.trajectory(objective="fuel")
+flight = optimizer.trajectory(objective="fuel", scaling=True)
 
 # Demonstrate accessing the new fuel_cost column
 fuel_cost_val = float(np.sum(flight["fuel_cost"]))
@@ -35,7 +35,6 @@ print(f"Fuel Cost: {fuel_cost_val:.2f} | Objective: {obj:.2f} | Status: {status}
 # flight = optimizer.trajectory(objective="gtp100")
 # flight = optimizer.trajectory(objective=("ci:90", "ci:10", "ci:20"))  # Multiphase
 
-print(flight)
 
 print(f"\nOptimal trajectory was generated in {round(time.time() - start)} seconds.\n")
 

--- a/openap/top/base.py
+++ b/openap/top/base.py
@@ -280,7 +280,6 @@ class Base:
             "ipopt.file_print_level": 5 if debug else 0,
             "ipopt.nlp_scaling_method": "gradient-based",
             "ipopt.obj_scaling_factor": 1.0,
-            "ipopt.limited_memory_max_history": 50,
         }
 
         if debug:

--- a/openap/top/base.py
+++ b/openap/top/base.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import casadi as ca
 import openap.casadi as oc
 from openap.extra.aero import fpm, ft, kts
-
+from types import SimpleNamespace
 import numpy as np
 import openap
 import pandas as pd
@@ -50,7 +50,7 @@ class Base:
         self.aircraft = oc.prop.aircraft(self.actype, use_synonym=use_synonym)
         self.engtype = self.aircraft["engine"]["default"]
         self.engine = oc.prop.engine(self.aircraft["engine"]["default"])
-
+        self.h_cr = self.aircraft["cruise"]["height"]
         self.mass_init = m0 * self.aircraft["mtow"]
         self.oew = self.aircraft["oew"]
         self.mlw = self.aircraft["mlw"]
@@ -87,7 +87,25 @@ class Base:
             warnings.warn("The destination is likely out of maximum cruise range.")
 
         self.debug = False
+        self.reset_scaling()
         self.setup()
+
+    def reset_scaling(self):
+        self.scale_x = 1.0
+        self.scale_y = 1.0
+        self.scale_h = 1.0
+        self.scale_m = 1.0
+        self.scale_t = 1.0
+        self.scale_mach = 1.0
+        self.scale_vs = 1.0
+        self.scale_psi = 1.0
+        self.scale_force = 1.0
+        self.scale_energy = 1.0
+        self.scale_obj = 1.0
+
+    def set_scaling(self, **scales):
+        for k, v in scales.items():
+            setattr(self, k, v)
 
     def proj(self, lon, lat, inverse=False, symbolic=False):
         lat0 = (self.lat1 + self.lat2) / 2
@@ -268,9 +286,9 @@ class Base:
         self.solver_options = {
             "print_time": 1 if debug else 0,
             "calc_lam_p": False,
-            "ipopt.print_level": 5 if debug else 0,
+            "ipopt.print_level": 1 if debug else 0,
             "ipopt.sb": "yes",
-            "ipopt.max_iter": kwargs.get("max_iteration", kwargs.get("max_iterations", 3000)),
+            "ipopt.max_iter": kwargs.get("max_iteration", kwargs.get("max_iterations", 6000)),
             "ipopt.fixed_variable_treatment": "relax_bounds",
             "ipopt.tol": kwargs.get("tol", 1e-6),
             "ipopt.acceptable_tol": kwargs.get("acceptable_tol", 1e-4),
@@ -279,7 +297,7 @@ class Base:
             "ipopt.hessian_approximation": kwargs.get("hessian_approximation", "limited-memory"),
             "ipopt.file_print_level": 5 if debug else 0,
             "ipopt.nlp_scaling_method": "gradient-based",
-            "ipopt.obj_scaling_factor": 1.0,
+            # "ipopt.obj_scaling_factor": 1.0,
         }
 
         if debug:
@@ -303,6 +321,7 @@ class Base:
             self.solver_options[f"ipopt.{key}"] = value
 
     def init_model(self, objective, **kwargs):
+        # todo: make this better integrating with other scaling option
         autoscale_cost = kwargs.get("auto_scale_cost", False)
 
         # Model variables
@@ -580,13 +599,14 @@ class Base:
         mach, vs, psi = U
         lon, lat = self.proj(xp, yp, inverse=True)
         ts_ = np.linspace(0, ts_final, n).round(4)
+
         tas = (openap.aero.mach2tas(mach, h, dT=self.dT) / kts).round(4)
         alt = (h / ft).round()
         vertrate = (vs / fpm).round()
 
         # Calculate fuel_cost per segment
-        fuel_cost = self.obj_fuel(X, U, self.dt, symbolic=False)
-
+        # fuel_cost = self.obj_fuel(X, U, self.dt, symbolic=False)
+        fuel_cost = np.append(-np.diff(mass), np.nan)
         # Calculate grid_cost per segment (NaN if no interpolant)
         if interpolant is not None:
             grid_cost = self.obj_grid_cost(

--- a/openap/top/base.py
+++ b/openap/top/base.py
@@ -1,6 +1,6 @@
 import warnings
 from typing import Callable, Union
-
+from pathlib import Path
 import casadi as ca
 import openap.casadi as oc
 from openap.extra.aero import fpm, ft, kts
@@ -240,50 +240,65 @@ class Base:
         nodes: int | None = None,
         polydeg: int = 3,
         debug=False,
+        results_path: str | Path | None = None,
         ipopt_kwargs={},
         **kwargs,
     ):
+        if results_path is None:
+            try:
+                results_path = Path(__file__).parent
+            except NameError:
+                results_path = Path.cwd()
+        else:
+            results_path = Path(results_path)
+
+        self.results_path = results_path
+
         if nodes is not None:
             self.nodes = nodes
         else:
             self.nodes = int(self.range / 50_000)  # node every 50km
 
         max_nodes = kwargs.get("max_nodes", 120)
-
         self.nodes = max(20, self.nodes)
         self.nodes = min(max_nodes, self.nodes)
-
         self.polydeg = polydeg
-
-        max_iteration = kwargs.get("max_iteration", kwargs.get("max_iterations", 3000))
-        tol = kwargs.get("tol", 1e-6)
-        acceptable_tol = kwargs.get("acceptable_tol", 1e-4)
-        alpha_for_y = kwargs.get("alpha_for_y", "primal-and-full")
-        hessian_approximation = kwargs.get("hessian_approximation", "limited-memory")
-
         self.debug = debug
 
-        if debug:
-            print("Calculating optimal trajectory...")
-            ipopt_print = 5
-            print_time = 1
-        else:
-            ipopt_print = 0
-            print_time = 0
-
         self.solver_options = {
-            "print_time": print_time,
+            "print_time": 1 if debug else 0,
             "calc_lam_p": False,
-            "ipopt.print_level": ipopt_print,
+            "ipopt.print_level": 5 if debug else 0,
             "ipopt.sb": "yes",
-            "ipopt.max_iter": max_iteration,
+            "ipopt.max_iter": kwargs.get("max_iteration", kwargs.get("max_iterations", 3000)),
             "ipopt.fixed_variable_treatment": "relax_bounds",
-            "ipopt.tol": tol,
-            "ipopt.acceptable_tol": acceptable_tol,
+            "ipopt.tol": kwargs.get("tol", 1e-6),
+            "ipopt.acceptable_tol": kwargs.get("acceptable_tol", 1e-4),
             "ipopt.mu_strategy": "adaptive",
-            "ipopt.alpha_for_y": alpha_for_y,
-            "ipopt.hessian_approximation": hessian_approximation,
+            "ipopt.alpha_for_y": kwargs.get("alpha_for_y", "primal-and-full"),
+            "ipopt.hessian_approximation": kwargs.get("hessian_approximation", "limited-memory"),
+            "ipopt.file_print_level": 5 if debug else 0,
+            "ipopt.nlp_scaling_method": "gradient-based",
+            "ipopt.obj_scaling_factor": 1.0,
+            "ipopt.limited_memory_max_history": 50,
         }
+
+        if debug:
+            self.results_path.mkdir(parents=True, exist_ok=True)
+            existing = list(self.results_path.glob("ipopt_*.txt"))
+            numbers = []
+
+            for f in existing:
+                try:
+                    numbers.append(int(f.stem.split("_")[1]))
+                except (IndexError, ValueError):
+                    pass
+
+            next_num = max(numbers, default=0) + 1
+
+            ipopt_file = self.results_path / f"ipopt_{next_num}.txt"
+
+            self.solver_options["ipopt.output_file"] = str(ipopt_file)
 
         for key, value in ipopt_kwargs.items():
             self.solver_options[f"ipopt.{key}"] = value

--- a/openap/top/cruise.py
+++ b/openap/top/cruise.py
@@ -51,35 +51,184 @@ class Cruise(Base):
         hdg = oc.aero.bearing(self.lat1, self.lon1, self.lat2, self.lon2)
         psi = hdg * pi / 180
 
-        # Initial conditions - Lower upper bounds
-        self.x_0_lb = [xp_0, yp_0, h_min, self.mass_init, ts_min]
-        self.x_0_ub = [xp_0, yp_0, h_max, self.mass_init, ts_min]
+        scaling = kwargs.get("scaling", False)
+        if scaling:
+            self.set_scaling(
+                scale_x=max(abs(x_max - x_min) / 2, 1.0),
+                scale_y=max(abs(y_max - y_min) / 2, 1.0),
+                scale_h=max(h_max, 1.0),
+                scale_m=max(self.mass_init, 1.0),
+                scale_t=max(ts_max, 1.0),
 
-        # Final conditions - Lower and upper bounds
-        self.x_f_lb = [xp_f, yp_f, h_min, self.oew, ts_min]
-        self.x_f_ub = [xp_f, yp_f, h_max, self.mass_init, ts_max]
+                scale_mach=1.0,
+                scale_vs=2500 * fpm,
+                scale_psi=np.pi,
 
-        # States - Lower and upper bounds
-        self.x_lb = [x_min, y_min, h_min, self.oew, ts_min]
-        self.x_ub = [x_max, y_max, h_max, self.mass_init, ts_max]
+                scale_force=50000.0,
+                scale_energy=1e6,
+                scale_obj=1.0,
+            )
 
-        # Control init - lower and upper bounds
-        self.u_0_lb = [0.5, -500 * fpm, psi - pi / 4]
-        self.u_0_ub = [self.mach_max, 500 * fpm, psi + pi / 4]
+        # Store unscaled values for reference
+        self.x_0_unscaled = [xp_0, yp_0, h_min, self.mass_init, ts_min]
+        self.x_f_unscaled = [xp_f, yp_f, h_min, None, None]  # mass and time vary
 
-        # Control final - lower and upper bounds
-        self.u_f_lb = [0.5, -500 * fpm, psi - pi / 4]
-        self.u_f_ub = [self.mach_max, 500 * fpm, psi + pi / 4]
+        # ============================================================
+        # SCALED INITIAL CONDITIONS
+        # ============================================================
+        self.x_0_lb = [
+            xp_0 / self.scale_x,
+            yp_0 / self.scale_y,
+            h_min / self.scale_h,
+            self.mass_init / self.scale_m,
+            ts_min / self.scale_t
+        ]
+        self.x_0_ub = [
+            xp_0 / self.scale_x,
+            yp_0 / self.scale_y,
+            h_max / self.scale_h,
+            self.mass_init / self.scale_m,
+            ts_min / self.scale_t
+        ]
 
-        # Control - Lower and upper bound
-        self.u_lb = [0.5, -500 * fpm, psi - pi / 2]
-        self.u_ub = [self.mach_max, 500 * fpm, psi + pi / 2]
+        # ============================================================
+        # SCALED FINAL CONDITIONS
+        # ============================================================
+        self.x_f_lb = [
+            xp_f / self.scale_x,
+            yp_f / self.scale_y,
+            h_min / self.scale_h,
+            (self.oew) / self.scale_m,
+            ts_min / self.scale_t
+        ]
+        self.x_f_ub = [
+            xp_f / self.scale_x,
+            yp_f / self.scale_y,
+            h_max / self.scale_h,
+            self.mass_init / self.scale_m,
+            ts_max / self.scale_t
+        ]
 
-        # Initial guess - states
+        # ============================================================
+        # SCALED STATE BOUNDS
+        # ============================================================
+        self.x_lb = [
+            x_min / self.scale_x,
+            y_min / self.scale_y,
+            h_min / self.scale_h,
+            (self.oew) / self.scale_m,
+            ts_min / self.scale_t
+        ]
+        self.x_ub = [
+            x_max / self.scale_x,
+            y_max / self.scale_y,
+            h_max / self.scale_h,
+            self.mass_init / self.scale_m,
+            ts_max / self.scale_t
+        ]
+
+        # ============================================================
+        # SCALED CONTROL BOUNDS
+        # ============================================================
+        self.u_0_lb = [
+            0.5 / self.scale_mach,
+            (-500 * fpm) / self.scale_vs,
+            (psi - pi / 4) / self.scale_psi
+        ]
+        self.u_0_ub = [
+            self.mach_max / self.scale_mach,
+            (500 * fpm) / self.scale_vs,
+            (psi + pi / 4) / self.scale_psi
+        ]
+
+        self.u_f_lb = [
+            0.5 / self.scale_mach,
+            (-500 * fpm) / self.scale_vs,
+            (psi - pi / 4) / self.scale_psi
+        ]
+        self.u_f_ub = [
+            self.mach_max / self.scale_mach,
+            (500 * fpm) / self.scale_vs,
+            (psi + pi / 4) / self.scale_psi
+        ]
+
+        self.u_lb = [
+            0.5 / self.scale_mach,
+            (-500 * fpm) / self.scale_vs,
+            (psi - pi / 2) / self.scale_psi
+        ]
+        self.u_ub = [
+            self.mach_max / self.scale_mach,
+            (500 * fpm) / self.scale_vs,
+            (psi + pi / 2) / self.scale_psi
+        ]
+
+        # ============================================================
+        # SCALED INITIAL GUESS
+        # ============================================================
         self.x_guess = self.initial_guess()
+        for i in range(len(self.x_guess)):
+            self.x_guess[i][0] /= self.scale_x
+            self.x_guess[i][1] /= self.scale_y
+            self.x_guess[i][2] /= self.scale_h
+            self.x_guess[i][3] /= self.scale_m
+            self.x_guess[i][4] /= self.scale_t
+        self.u_guess = [0.7 / self.scale_mach, 0, psi / self.scale_psi]
 
-        # Initial guess - controls
-        self.u_guess = [0.7, 0, psi]
+    def unscale_state(self, x_scaled):
+        """Unscale state variables back to physical units."""
+        x_unscaled = x_scaled.copy()
+        x_unscaled[0] *= self.scale_x
+        x_unscaled[1] *= self.scale_y
+        x_unscaled[2] *= self.scale_h
+        x_unscaled[3] *= self.scale_m
+        x_unscaled[4] *= self.scale_t
+        return x_unscaled
+
+    def unscale_control(self, u_scaled):
+        """Unscale control variables back to physical units."""
+        u_unscaled = u_scaled.copy()
+        u_unscaled[0] *= self.scale_mach
+        u_unscaled[1] *= self.scale_vs
+        u_unscaled[2] *= self.scale_psi
+        return u_unscaled
+
+    def scaled_dynamics(self, x_scaled, u_scaled):
+        """
+        Compute dynamics with scaled variables.
+        Returns scaled derivatives and scaled objective contribution.
+        """
+        # Unscale for dynamics computation
+        x_unscaled = ca.vertcat(
+            x_scaled[0] * self.scale_x,
+            x_scaled[1] * self.scale_y,
+            x_scaled[2] * self.scale_h,
+            x_scaled[3] * self.scale_m,
+            x_scaled[4] * self.scale_t
+        )
+        u_unscaled = ca.vertcat(
+            u_scaled[0] * self.scale_mach,
+            u_scaled[1] * self.scale_vs,
+            u_scaled[2] * self.scale_psi
+        )
+
+        # Compute unscaled dynamics
+        f_unscaled, q_unscaled = self.func_dynamics(x_unscaled, u_unscaled)
+
+        # Scale derivatives: dx_scaled/dt = (dx/dt) / scale
+        # But dt is also scaled, so: dx_scaled/dt_scaled = (dx/dt) * (scale_t / scale_x)
+        f_scaled = ca.vertcat(
+            f_unscaled[0] * (self.scale_t / self.scale_x),
+            f_unscaled[1] * (self.scale_t / self.scale_y),
+            f_unscaled[2] * (self.scale_t / self.scale_h),
+            f_unscaled[3] * (self.scale_t / self.scale_m),
+            f_unscaled[4]  # dt/dt = 1 (no scaling needed)
+        )
+
+        # Scale objective (if needed)
+        q_scaled = q_unscaled * self.scale_t / self.scale_obj
+
+        return f_scaled, q_scaled
 
     def trajectory(self, objective="fuel", **kwargs) -> pd.DataFrame:
         """
@@ -109,10 +258,16 @@ class Cruise(Base):
         self.init_model(objective, **kwargs)
 
         customized_max_fuel = kwargs.get("max_fuel", None)
-
+        scaling = kwargs.get("scaling")
         initial_guess = kwargs.get("initial_guess", None)
         if initial_guess is not None:
             self.x_guess = self.initial_guess(initial_guess)
+            for i in range(len(self.x_guess)):
+                self.x_guess[i][0] /= self.scale_x
+                self.x_guess[i][1] /= self.scale_y
+                self.x_guess[i][2] /= self.scale_h
+                self.x_guess[i][3] /= self.scale_m
+                self.x_guess[i][4] /= self.scale_t
 
         return_failed = kwargs.get("return_failed", False)
 
@@ -180,7 +335,12 @@ class Cruise(Base):
                     xpc = xpc + C[r + 1, j] * Xc[r]
 
                 # Append collocation equations
-                fj, qj = self.func_dynamics(Xc[j - 1], Uk)
+                # Use scaled dynamics
+                if scaling:
+                    fj, qj = self.scaled_dynamics(Xc[j - 1], Uk)
+                else:
+                    fj, qj = self.func_dynamics(Xc[j - 1], Uk)
+
                 g.append(self.dt * fj - xpc)
                 lbg.append([0] * nstates)
                 ubg.append([0] * nstates)
@@ -222,27 +382,34 @@ class Cruise(Base):
 
         # aircraft performane constraints
         for k in range(self.nodes):
+            # Unscale variables for constraint evaluation
+            mass = X[k][3] * self.scale_m
+            h = X[k][2] * self.scale_h
+            mach = U[k][0] * self.scale_mach
+            vs = U[k][1] * self.scale_vs
+
             S = self.aircraft["wing"]["area"]
-            mass = X[k][3]
-            v = oc.aero.mach2tas(U[k][0], X[k][2], dT=self.dT)
+            cd0 = self.drag.polar["clean"]["cd0"]
+            ck = self.drag.polar["clean"]["k"]
+
+            v = oc.aero.mach2tas(mach, h, dT=self.dT)
             tas = v / kts
-            alt = X[k][2] / ft
-            rho = oc.aero.density(X[k][2], dT=self.dT)
+            alt = h / ft
+            rho = oc.aero.density(h, dT=self.dT)
             thrust_max = self.thrust.cruise(tas, alt, dT=self.dT)
+            drag = self.drag.clean(mass, tas, alt, dT=self.dT)
 
             # max_thrust * 95% > drag (5% margin)
-            g.append(thrust_max * 0.95 - self.drag.clean(mass, tas, alt, dT=self.dT))
+            g.append((thrust_max * 0.95 - drag) / self.scale_force)
             lbg.append([0])
             ubg.append([ca.inf])
 
             # max lift * 80% > weight (20% margin)
             drag_max = thrust_max * 0.9
-            cd_max = drag_max / (0.5 * rho * v**2 * S + 1e-10)
-            cd0 = self.drag.polar["clean"]["cd0"]
-            ck = self.drag.polar["clean"]["k"]
+            cd_max = drag_max / (0.5 * rho * v ** 2 * S + 1e-10)
             cl_max = ca.sqrt(ca.fmax(1e-10, (cd_max - cd0) / ck))
-            L_max = cl_max * 0.5 * rho * v**2 * S
-            g.append(L_max * 0.8 - mass * oc.aero.g0)
+            L_max = cl_max * 0.5 * rho * v ** 2 * S
+            g.append((L_max * 0.8 - mass * oc.aero.g0) / self.scale_force)
             lbg.append([0])
             ubg.append([ca.inf])
 
@@ -267,8 +434,8 @@ class Cruise(Base):
         # smooth heading change
         for k in range(self.nodes - 1):
             g.append(U[k + 1][2] - U[k][2])
-            lbg.append([-15 * pi / 180])
-            ubg.append([15 * pi / 180])
+            lbg.append([(-15 * pi / 180) / self.scale_psi])
+            ubg.append([(15 * pi / 180) / self.scale_psi])
 
         # optional constraints
         if self.fix_mach:
@@ -295,13 +462,16 @@ class Cruise(Base):
                 lbg.append([0])
                 ubg.append([ca.inf])
 
-        # add fuel constraint
-        g.append(X[0][3] - X[-1][3])
+        fuel_consumed_scaled = (X[0][3] - X[-1][3])  # Already in scaled units
+        fuel_max_scaled = self.fuel_max / self.scale_m
+
+        g.append(fuel_consumed_scaled)
         lbg.append([0])
-        ubg.append([self.fuel_max])
+        ubg.append([fuel_max_scaled])
 
         if customized_max_fuel is not None:
-            g.append(X[0][3] - X[-1][3] - customized_max_fuel)
+            custom_fuel_scaled = customized_max_fuel / self.scale_m
+            g.append(fuel_consumed_scaled - custom_fuel_scaled)
             lbg.append([-ca.inf])
             ubg.append([0])
 
@@ -324,10 +494,27 @@ class Cruise(Base):
 
         # final timestep
         ts_final = self.solution["x"][-1].full()[0][0]
-
+        ts_final *= self.scale_t
         # Function to get x and u from w
         output = ca.Function("output", [w], [X, U], ["w"], ["x", "u"])
         x_opt, u_opt = output(self.solution["x"])
+
+        # Unscale solution if scaling was used
+        x_opt_unscaled = x_opt.full()
+        u_opt_unscaled = u_opt.full()
+
+        x_opt_unscaled[0, :] *= self.scale_x
+        x_opt_unscaled[1, :] *= self.scale_y
+        x_opt_unscaled[2, :] *= self.scale_h
+        x_opt_unscaled[3, :] *= self.scale_m
+        x_opt_unscaled[4, :] *= self.scale_t
+
+        u_opt_unscaled[0, :] *= self.scale_mach
+        u_opt_unscaled[1, :] *= self.scale_vs
+        u_opt_unscaled[2, :] *= self.scale_psi
+
+        x_opt = ca.DM(x_opt_unscaled)
+        u_opt = ca.DM(u_opt_unscaled)
 
         df = self.to_trajectory(ts_final, x_opt, u_opt, **kwargs)
 

--- a/openap/top/full.py
+++ b/openap/top/full.py
@@ -1,11 +1,12 @@
 import warnings
 from math import pi
-
+from pathlib import Path
 import casadi as ca
 import numpy as np
 import openap
 import openap.casadi as oc
 import pandas as pd
+from mpmath.libmp.libmpf import h_mask
 from openap.extra.aero import fpm, ft, kts
 
 from .base import Base
@@ -56,43 +57,194 @@ class CompleteFlight(Base):
         y_max = max(yp_0, yp_f) + 10_000
 
         ts_min = 0
-        ts_max = max(5, self.range / 1000 / 500) * 3600
+        ts_max = max(5, self.range / 1000 / 500) * 3600  # max time of 5 hours
 
         h_max = kwargs.get("h_max", self.aircraft["limits"]["ceiling"])
         h_min = 100 * ft
-
+        # h_max = 11000*ft + 2000
+        # h_min = 11000*ft - 2000
         hdg = oc.aero.bearing(self.lat1, self.lon1, self.lat2, self.lon2)
         psi = hdg * pi / 180
 
-        # Initial conditions - Lower upper bounds
-        self.x_0_lb = [xp_0, yp_0, h_min, self.mass_init, ts_min]
-        self.x_0_ub = [xp_0, yp_0, h_min, self.mass_init, ts_min]
+        scaling = kwargs.get("scaling", False)
 
-        # Final conditions - Lower and upper bounds
-        self.x_f_lb = [xp_f, yp_f, h_min, self.oew * 0.5, ts_min]
-        self.x_f_ub = [xp_f, yp_f, h_min, self.mass_init, ts_max]
+        if scaling:
+            self.set_scaling(
+                scale_x=max(abs(x_max - x_min) / 2, 1.0),
+                scale_y=max(abs(y_max - y_min) / 2, 1.0),
+                scale_h=max(h_max, 1.0),
+                scale_m=max(self.mass_init, 1.0),
+                scale_t=max(ts_max, 1.0),
 
-        # States - Lower and upper bounds
-        self.x_lb = [x_min, y_min, h_min, self.oew * 0.5, ts_min]
-        self.x_ub = [x_max, y_max, h_max, self.mass_init, ts_max]
+                scale_mach=1.0,
+                scale_vs=2500 * fpm,
+                scale_psi=np.pi,
 
-        # Control init - lower and upper bounds
-        self.u_0_lb = [0.1, 500 * fpm, psi]
-        self.u_0_ub = [0.3, 2500 * fpm, psi]
+                scale_force=50000.0,
+                scale_energy=1e6,
+                scale_obj=1.0,
+            )
 
-        # Control final - lower and upper bounds
-        self.u_f_lb = [0.1, -1500 * fpm, psi]
-        self.u_f_ub = [0.3, -300 * fpm, psi]
+        # Store unscaled values for reference
+        self.x_0_unscaled = [xp_0, yp_0, h_min, self.mass_init, ts_min]
+        self.x_f_unscaled = [xp_f, yp_f, h_min, None, None]  # mass and time vary
 
-        # Control - Lower and upper bound
-        self.u_lb = [0.1, -2500 * fpm, psi - pi / 2]
-        self.u_ub = [self.mach_max, 2500 * fpm, psi + pi / 2]
+        # ============================================================
+        # SCALED INITIAL CONDITIONS
+        # ============================================================
+        self.x_0_lb = [
+            xp_0 / self.scale_x,
+            yp_0 / self.scale_y,
+            h_min / self.scale_h,
+            self.mass_init / self.scale_m,
+            ts_min / self.scale_t
+        ]
+        self.x_0_ub = self.x_0_lb.copy()
 
-        # Initial guess for the states
+        # ============================================================
+        # SCALED FINAL CONDITIONS
+        # ============================================================
+        self.x_f_lb = [
+            xp_f / self.scale_x,
+            yp_f / self.scale_y,
+            h_min / self.scale_h,
+            (self.oew * 0.5) / self.scale_m,
+            ts_min / self.scale_t
+        ]
+        self.x_f_ub = [
+            xp_f / self.scale_x,
+            yp_f / self.scale_y,
+            h_min / self.scale_h,
+            self.mass_init / self.scale_m,
+            ts_max / self.scale_t
+        ]
+
+        # ============================================================
+        # SCALED STATE BOUNDS
+        # ============================================================
+        self.x_lb = [
+            x_min / self.scale_x,
+            y_min / self.scale_y,
+            h_min / self.scale_h,
+            (self.oew * 0.5) / self.scale_m,
+            ts_min / self.scale_t
+        ]
+        self.x_ub = [
+            x_max / self.scale_x,
+            y_max / self.scale_y,
+            h_max / self.scale_h,
+            self.mass_init / self.scale_m,
+            ts_max / self.scale_t
+        ]
+
+        # ============================================================
+        # SCALED CONTROL BOUNDS
+        # ============================================================
+        self.u_0_lb = [
+            0.1 / self.scale_mach,
+            (500 * fpm) / self.scale_vs,
+            psi / self.scale_psi
+        ]
+        self.u_0_ub = [
+            0.3 / self.scale_mach,
+            (2500 * fpm) / self.scale_vs,
+            psi / self.scale_psi
+        ]
+
+        self.u_f_lb = [
+            0.1 / self.scale_mach,
+            (-1500 * fpm) / self.scale_vs,
+            psi / self.scale_psi
+        ]
+        self.u_f_ub = [
+            0.3 / self.scale_mach,
+            (-300 * fpm) / self.scale_vs,
+            psi / self.scale_psi
+        ]
+
+        self.u_lb = [
+            0.1 / self.scale_mach,
+            (-2500 * fpm) / self.scale_vs,
+            (psi - pi / 2) / self.scale_psi
+        ]
+        self.u_ub = [
+            self.mach_max / self.scale_mach,
+            (2500 * fpm) / self.scale_vs,
+            (psi + pi / 2) / self.scale_psi
+        ]
+
+        # ============================================================
+        # SCALED INITIAL GUESS
+        # ============================================================
         self.x_guess = self.initial_guess()
+        # Scale the guess
+        for i in range(len(self.x_guess)):
+            self.x_guess[i][0] /= self.scale_x
+            self.x_guess[i][1] /= self.scale_y
+            self.x_guess[i][2] /= self.scale_h
+            self.x_guess[i][3] /= self.scale_m
+            self.x_guess[i][4] /= self.scale_t
 
-        # Control - guesses
-        self.u_guess = [0.6, 1000 * fpm, psi]
+        self.u_guess = [
+            0.6 / self.scale_mach,
+            (1000 * fpm) / self.scale_vs,
+            psi / self.scale_psi
+        ]
+
+    def unscale_state(self, x_scaled):
+        """Unscale state variables back to physical units."""
+        x_unscaled = x_scaled.copy()
+        x_unscaled[0] *= self.scale_x
+        x_unscaled[1] *= self.scale_y
+        x_unscaled[2] *= self.scale_h
+        x_unscaled[3] *= self.scale_m
+        x_unscaled[4] *= self.scale_t
+        return x_unscaled
+
+    def unscale_control(self, u_scaled):
+        """Unscale control variables back to physical units."""
+        u_unscaled = u_scaled.copy()
+        u_unscaled[0] *= self.scale_mach
+        u_unscaled[1] *= self.scale_vs
+        u_unscaled[2] *= self.scale_psi
+        return u_unscaled
+
+    def scaled_dynamics(self, x_scaled, u_scaled):
+        """
+        Compute dynamics with scaled variables.
+        Returns scaled derivatives and scaled objective contribution.
+        """
+        # Unscale for dynamics computation
+        x_unscaled = ca.vertcat(
+            x_scaled[0] * self.scale_x,
+            x_scaled[1] * self.scale_y,
+            x_scaled[2] * self.scale_h,
+            x_scaled[3] * self.scale_m,
+            x_scaled[4] * self.scale_t
+        )
+        u_unscaled = ca.vertcat(
+            u_scaled[0] * self.scale_mach,
+            u_scaled[1] * self.scale_vs,
+            u_scaled[2] * self.scale_psi
+        )
+
+        # Compute unscaled dynamics
+        f_unscaled, q_unscaled = self.func_dynamics(x_unscaled, u_unscaled)
+
+        # Scale derivatives: dx_scaled/dt = (dx/dt) / scale
+        # But dt is also scaled, so: dx_scaled/dt_scaled = (dx/dt) * (scale_t / scale_x)
+        f_scaled = ca.vertcat(
+            f_unscaled[0] * (self.scale_t / self.scale_x),
+            f_unscaled[1] * (self.scale_t / self.scale_y),
+            f_unscaled[2] * (self.scale_t / self.scale_h),
+            f_unscaled[3] * (self.scale_t / self.scale_m),
+            f_unscaled[4]  # dt/dt = 1 (no scaling needed)
+        )
+
+        # Scale objective (if needed)
+        q_scaled = q_unscaled * self.scale_t / self.scale_obj
+
+        return f_scaled, q_scaled
 
     def trajectory(self, objective="fuel", **kwargs) -> pd.DataFrame:
         """
@@ -106,7 +258,6 @@ class CompleteFlight(Base):
                 usually a exsiting flight trajectory.
             - return_failed (bool): If True, returns the DataFrame even if the
                 optimization fails. Default is False.
-            - autoscale_cost (bool): If True, objective is scaled based on initial guess
 
 
         Returns:
@@ -124,12 +275,19 @@ class CompleteFlight(Base):
         self.init_model(objective, **kwargs)
 
         customized_max_fuel = kwargs.get("max_fuel", None)
-
         initial_guess = kwargs.get("initial_guess", None)
+        scaling = kwargs.get("scaling")
+        return_failed = kwargs.get("return_failed", False)
+
         if initial_guess is not None:
             self.x_guess = self.initial_guess(initial_guess)
-
-        return_failed = kwargs.get("return_failed", False)
+            # Scale the guess if using scaling
+            for i in range(len(self.x_guess)):
+                self.x_guess[i][0] /= self.scale_x
+                self.x_guess[i][1] /= self.scale_y
+                self.x_guess[i][2] /= self.scale_h
+                self.x_guess[i][3] /= self.scale_m
+                self.x_guess[i][4] /= self.scale_t
 
         C, D, B = self.collocation_coeff()
 
@@ -195,7 +353,10 @@ class CompleteFlight(Base):
                     xpc = xpc + C[r + 1, j] * Xc[r]
 
                 # Append collocation equations
-                fj, qj = self.func_dynamics(Xc[j - 1], Uk)
+                if scaling:
+                    fj, qj = self.scaled_dynamics(Xc[j - 1], Uk)
+                else:
+                    fj, qj = self.func_dynamics(Xc[j - 1], Uk)
                 g.append(self.dt * fj - xpc)
                 lbg.append([0] * nstates)
                 ubg.append([0] * nstates)
@@ -204,7 +365,7 @@ class CompleteFlight(Base):
                 Xk_end = Xk_end + D[j] * Xc[j - 1]
 
                 # Add contribution to quadrature function
-                # J = J + B[j] * qj * dt
+                # J = J + B[j] * qj * self.dt
                 J = J + B[j] * qj
 
             # New NLP variable for state at end of interval
@@ -243,12 +404,11 @@ class CompleteFlight(Base):
             for k in range(idx_toc, idx_tod):
                 # minimum avoid large changes in altitude
                 g.append(U[k][1])
-                lbg.append([-500 * fpm])
-                ubg.append([500 * fpm])
+                lbg.append([(-500 * fpm) / self.scale_vs])
+                ubg.append([(500 * fpm) / self.scale_vs])
 
-                # minimum cruise alt FL150
                 g.append(X[k][2])
-                lbg.append([15000 * ft])
+                lbg.append([(15000 * ft) / self.scale_h])
                 ubg.append([ca.inf])
 
             for k in range(0, idx_toc):
@@ -263,36 +423,40 @@ class CompleteFlight(Base):
 
         # force and energy constraint
         for k in range(self.nodes):
+            # Unscale variables for constraint evaluation
+            mass = X[k][3] * self.scale_m
+            h = X[k][2] * self.scale_h
+            mach = U[k][0] * self.scale_mach
+            vs = U[k][1] * self.scale_vs
+
             S = self.aircraft["wing"]["area"]
             cd0 = self.drag.polar["clean"]["cd0"]
             ck = self.drag.polar["clean"]["k"]
-            mass = X[k][3]
-            v = oc.aero.mach2tas(U[k][0], X[k][2], dT=self.dT)
+
+            v = oc.aero.mach2tas(mach, h, dT=self.dT)
             tas = v / kts
-            alt = X[k][2] / ft
-            rho = oc.aero.density(X[k][2], dT=self.dT)
+            alt = h / ft
+            rho = oc.aero.density(h, dT=self.dT)
             thrust_max = self.thrust.cruise(tas, alt, dT=self.dT)
             drag = self.drag.clean(mass, tas, alt, dT=self.dT)
 
             # max_thrust > drag (5% margin)
-            g.append(thrust_max * 0.95 - drag)
+            g.append((thrust_max * 0.95 - drag) / self.scale_force)
             lbg.append([0])
             ubg.append([ca.inf])
 
             # max lift * 80% > weight (20% margin)
             drag_max = thrust_max * 0.9
-            cd_max = drag_max / (0.5 * rho * v**2 * S + 1e-10)
-            cd0 = self.drag.polar["clean"]["cd0"]
-            ck = self.drag.polar["clean"]["k"]
+            cd_max = drag_max / (0.5 * rho * v ** 2 * S + 1e-10)
             cl_max = ca.sqrt(ca.fmax(1e-10, (cd_max - cd0) / ck))
-            L_max = cl_max * 0.5 * rho * v**2 * S
-            g.append(L_max * 0.8 - mass * oc.aero.g0)
+            L_max = cl_max * 0.5 * rho * v ** 2 * S
+            g.append((L_max * 0.8 - mass * oc.aero.g0) / self.scale_force)
             lbg.append([0])
             ubg.append([ca.inf])
 
             # excess energy > change potential energy
-            excess_energy = (thrust_max - drag) * v - mass * oc.aero.g0 * U[k][1]
-            g.append(excess_energy)
+            excess_energy = (thrust_max - drag) * v - mass * oc.aero.g0 * vs
+            g.append(excess_energy / self.scale_energy)
             lbg.append([0])
             ubg.append([ca.inf])
 
@@ -305,30 +469,43 @@ class CompleteFlight(Base):
         # smooth Mach number change
         for k in range(self.nodes - 1):
             g.append(U[k + 1][0] - U[k][0])
-            lbg.append([-0.2])
-            ubg.append([0.2])  # to be tunned
+            lbg.append([-0.2 / self.scale_mach])
+            ubg.append([0.2 / self.scale_mach])
 
         # smooth vertical rate change
         for k in range(self.nodes - 1):
             g.append(U[k + 1][1] - U[k][1])
-            lbg.append([-500 * fpm])
-            ubg.append([500 * fpm])  # to be tunned
+            lbg.append([(-500 * fpm) / self.scale_vs])
+            ubg.append([(500 * fpm) / self.scale_vs])
 
         # smooth heading change
         for k in range(self.nodes - 1):
             g.append(U[k + 1][2] - U[k][2])
-            lbg.append([-15 * pi / 180])
-            ubg.append([15 * pi / 180])
+            lbg.append([(-15 * pi / 180) / self.scale_psi])
+            ubg.append([(15 * pi / 180) / self.scale_psi])
 
-        # add fuel constraint
-        g.append(X[0][3] - X[-1][3])
+        fuel_consumed_scaled = (X[0][3] - X[-1][3])  # Already in scaled units
+        fuel_max_scaled = self.fuel_max / self.scale_m
+
+        g.append(fuel_consumed_scaled)
         lbg.append([0])
-        ubg.append([self.fuel_max])
+        ubg.append([fuel_max_scaled])
 
         if customized_max_fuel is not None:
-            g.append(X[0][3] - X[-1][3] - customized_max_fuel)
+            custom_fuel_scaled = customized_max_fuel / self.scale_m
+            g.append(fuel_consumed_scaled - custom_fuel_scaled)
             lbg.append([-ca.inf])
             ubg.append([0])
+
+        # # add fuel constraint
+        # g.append(X[0][3] - X[-1][3])
+        # lbg.append([0])
+        # ubg.append([self.fuel_max])
+        #
+        # if customized_max_fuel is not None:
+        #     g.append(X[0][3] - X[-1][3] - customized_max_fuel)
+        #     lbg.append([-ca.inf])
+        #     ubg.append([0])
 
         # Concatenate vectors
         w = ca.vertcat(*w)
@@ -350,13 +527,29 @@ class CompleteFlight(Base):
 
         # final timestep
         ts_final = self.solution["x"][-1].full()[0][0]
-
+        ts_final *= self.scale_t
         # Function to get x and u from w
         output = ca.Function("output", [w], [X, U], ["w"], ["x", "u"])
         x_opt, u_opt = output(self.solution["x"])
 
-        df = self.to_trajectory(ts_final, x_opt, u_opt, **kwargs)
+        # Unscale solution if scaling was used
+        x_opt_unscaled = x_opt.full()
+        u_opt_unscaled = u_opt.full()
 
+        x_opt_unscaled[0, :] *= self.scale_x
+        x_opt_unscaled[1, :] *= self.scale_y
+        x_opt_unscaled[2, :] *= self.scale_h
+        x_opt_unscaled[3, :] *= self.scale_m
+        x_opt_unscaled[4, :] *= self.scale_t
+
+        u_opt_unscaled[0, :] *= self.scale_mach
+        u_opt_unscaled[1, :] *= self.scale_vs
+        u_opt_unscaled[2, :] *= self.scale_psi
+
+        x_opt = ca.DM(x_opt_unscaled)
+        u_opt = ca.DM(u_opt_unscaled)
+
+        df = self.to_trajectory(ts_final, x_opt, u_opt, **kwargs)
         df_copy = df.copy()
 
         # check if the optimizer has failed


### PR DESCRIPTION
This PR introduces optional variable scaling to the direct collocation NLP formulation in Cruise and CompleteFlight. Scaling normalizes state and control variables before passing them to the solver, which can significantly improve IPOPT convergence behavior — especially for long-haul routes where state variables span several orders of magnitude (e.g., position in meters vs. Mach numbers near 0.8).

**Motivation**
The NLP formulation involves state variables with very different physical magnitudes:

Position (x, y): on the order of 10⁶ m
Altitude (h): ~10⁴ m
Mass (m): ~10⁴–10⁵ kg
Time (ts): ~10³–10⁴ s
Mach: ~0.8
Vertical speed: ~0.1–10 m/s

Without scaling, the Hessian and Jacobian of the NLP become poorly conditioned, making it harder for IPOPT to find descent directions and slowing or preventing convergence.

**Changes**
base.py

Added reset_scaling() to initialize all scale factors to 1.0 (identity — no effect by default)
Added set_scaling(**scales) to allow overriding individual scale factors

cruise.py and complete_flight.py

init_conditions() now accepts a scaling=True/False kwarg. When enabled, scale factors are computed from the problem bounds and set via set_scaling()
All bounds (x_0_lb/ub, x_f_lb/ub, x_lb/ub, u_lb/ub, etc.) and initial guesses are divided by their respective scale factors before being passed to the NLP
Added scaled_dynamics() method: unscales variables, calls the original func_dynamics, then rescales the returned derivatives (accounting for the time scaling in the chain rule: dx_scaled/dt_scaled = (dx/dt) * (scale_t / scale_x))
In trajectory(), scaled dynamics are used in the collocation constraints when scaling=True
After solving, the solution is unscaled back to physical units before being passed to to_trajectory()
Performance constraints (thrust, lift) always unscale relevant variables before evaluation, making them scale-agnostic

**Backward compatibility**
Scaling is opt-in via scaling=False default. Existing code calling .trajectory() without the scaling kwarg behaves identically to before.
Usage
See quick_test.py example

**Notes**
The scale_obj factor is scaffolded but left at 1.0 for now; objective scaling can be layered on top separately
auto_scale_cost in init_model is a related experimental feature for automatic objective normalization, separate from this PR's variable scaling.