### PR TITLE
Add ordered waypoint constraints

### DIFF
--- a/examples/waypoints.py
+++ b/examples/waypoints.py
@@ -1,0 +1,50 @@
+"""Waypoint-constrained cruise optimization example.
+
+Run from the repository root with:
+
+    uv run python examples/waypoints.py
+"""
+
+from __future__ import annotations
+
+import openap
+
+import opentop as top
+import pandas as pd
+
+FIX_NAMES = ("ARNEM", "KENUM", "DODEN", "BOMBI")
+
+
+def openap_waypoints(fix_names: tuple[str, ...]) -> list[tuple[float, float]]:
+    """Load named fixes from OpenAP's packaged navigation database."""
+    waypoints = []
+    for fix_name in fix_names:
+        lat, lon, _ = openap.nav.fix(fix_name)
+        waypoints.append((float(lat), float(lon)))
+    return waypoints
+
+
+def main() -> None:
+    opt = top.Cruise("A320", "EHAM", "EDDF", 0.85)
+    waypoints = openap_waypoints(FIX_NAMES)
+
+    flight = opt.trajectory(
+        objective="fuel",
+        waypoints=waypoints,
+        waypoint_tolerance_m=20_000,
+    )
+    assert isinstance(flight, pd.DataFrame)
+
+    print("Route: EHAM -> " + " -> ".join(FIX_NAMES) + " -> EDDF")
+    for fix_name, waypoint in zip(FIX_NAMES, waypoints):
+        distances = [
+            openap.aero.distance(lat, lon, waypoint[0], waypoint[1])
+            for lat, lon in zip(flight.latitude, flight.longitude)
+        ]
+        print(f"{fix_name}: closest trajectory point {min(distances) / 1000:.1f} km")
+    print(f"Fuel burn: {flight.mass.iloc[0] - flight.mass.iloc[-1]:.1f} kg")
+    print(f"Elapsed time: {flight.ts.iloc[-1] / 60:.1f} min")
+
+
+if __name__ == "__main__":
+    main()

--- a/opentop/_trajectory.py
+++ b/opentop/_trajectory.py
@@ -74,12 +74,13 @@ def to_dataframe(
     U = np.append(U, U[:, -1:], axis=1)
     n = nodes + 1
 
-    dt = ts_final / (n - 1)
-
     xp, yp, h, mass, ts = X
     mach, vs, psi = U
     lon, lat = proj(xp, yp, inverse=True)
-    ts_ = np.linspace(0, ts_final, n).round(4)
+    ts_values = np.asarray(ts, dtype=float)
+    ts_ = ts_values.round(4)
+    dt = float(ts_final) / (n - 1)
+    segment_dt = np.diff(ts_values)
     tas = (openap.aero.mach2tas(mach, h, dT=dT) / kts).round(4)  # type: ignore[arg-type]  # openap stubs say int, float works
     alt = (h / ft).round()
     vertrate = (vs / fpm).round()
@@ -99,7 +100,7 @@ def to_dataframe(
             _objectives.obj_grid_cost(
                 X[:, :-1],
                 U[:, :-1],
-                dt,
+                segment_dt,
                 proj=proj,
                 interpolant=interpolant,
                 time_dependent=time_dependent,

--- a/opentop/base.py
+++ b/opentop/base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import warnings
+from itertools import pairwise
 from typing import TYPE_CHECKING, Any, Callable, ClassVar
 
 import casadi as ca
@@ -237,7 +238,7 @@ class Base:
             return lon, lat
 
     def _compute_bbox(
-        self, margin_m: float = 10_000
+        self, margin_m: float = 10_000, waypoints: Any = None
     ) -> tuple[float, float, float, float]:
         """Compute projected bounding box around origin/destination with margin.
 
@@ -245,10 +246,17 @@ class Base:
         """
         xp_0, yp_0 = self.proj(self.lon1, self.lat1)
         xp_f, yp_f = self.proj(self.lon2, self.lat2)
-        x_min = min(xp_0, xp_f) - margin_m
-        x_max = max(xp_0, xp_f) + margin_m
-        y_min = min(yp_0, yp_f) - margin_m
-        y_max = max(yp_0, yp_f) + margin_m
+        xs = [xp_0, xp_f]
+        ys = [yp_0, yp_f]
+        for lat, lon in self._normalize_waypoints(waypoints):
+            xp, yp = self.proj(lon, lat)
+            xs.append(xp)
+            ys.append(yp)
+
+        x_min = min(xs) - margin_m
+        x_max = max(xs) + margin_m
+        y_min = min(ys) - margin_m
+        y_max = max(ys) + margin_m
         return x_min, x_max, y_min, y_max
 
     def _compute_bearing_psi(self) -> float:
@@ -404,6 +412,7 @@ class Base:
         self.x = ca.vertcat(xp, yp, h, m, ts)
         self.u = ca.vertcat(mach, vs, psi)
 
+        interval_dt = ca.MX.sym("dt")  # type: ignore[arg-type]
         # self.ts_final and self.dt are set by _build_opti() before this call
 
         # Handle objective function. User callables expect `self.obj_*`
@@ -412,20 +421,20 @@ class Base:
         # injected here.
         if isinstance(objective, Callable):
             self.objective = objective
-            L = self.objective(self.x, self.u, self.dt, **kwargs)
+            L = self.objective(self.x, self.u, interval_dt, **kwargs)
         else:
             resolved = _objectives.resolve_objective(objective)
             ctx = self._objective_ctx()
             ctx.update(kwargs)
             self.objective = lambda x, u, dt, **kw: resolved(x, u, dt, **{**ctx, **kw})
-            L = resolved(self.x, self.u, self.dt, **ctx)
+            L = resolved(self.x, self.u, interval_dt, **ctx)
 
         # Continuous time dynamics
         self.func_dynamics = ca.Function(
             "f",
-            [self.x, self.u],
+            [self.x, self.u, interval_dt],
             [self.xdot(self.x, self.u), L],
-            ["x", "u"],
+            ["x", "u", "dt"],
             ["xdot", "L"],
             {"allow_free": True},
         )
@@ -441,7 +450,7 @@ class Base:
         Args:
             objective: Objective function name or callable.
             ts_final_guess: Initial guess for total flight time (seconds).
-            **kwargs: Passed through to init_model().
+            **kwargs: Solver construction options and objective options.
 
         Returns:
             tuple: (X, U) where X is list of state MX vars at each node boundary
@@ -475,9 +484,27 @@ class Base:
         self._opti.subject_to(self.ts_final >= 0)
         self._opti.set_initial(self.ts_final, ts_final_guess)
         self.dt = self.ts_final / self.nodes
+        variable_timestep = bool(
+            kwargs.get("variable_timestep", kwargs.get("waypoints") is not None)
+        )
+        self._variable_timestep = variable_timestep
+        self._interval_dts: list[Any] = []
+        model_kwargs = {
+            key: value
+            for key, value in kwargs.items()
+            if key
+            not in {
+                "waypoints",
+                "waypoint_tolerance_m",
+                "waypoint_node_indices",
+                "variable_timestep",
+                "dt_min",
+                "dt_max",
+            }
+        }
 
         # Build dynamics function (captures self.dt with free ts_final)
-        self.init_model(objective, **kwargs)
+        self.init_model(objective, **model_kwargs)
 
         C, D, B = self.collocation_coeff()
         nstates = self.x.shape[0]
@@ -493,6 +520,18 @@ class Base:
         X.append(Xk)
 
         for k in range(self.nodes):
+            if variable_timestep:
+                interval_dt = self._opti.variable()
+                dt_min = kwargs.get("dt_min", 5.0)
+                dt_max = kwargs.get("dt_max", self.x_f_ub[4])
+                self._opti.subject_to(self._opti.bounded(dt_min, interval_dt, dt_max))  # type: ignore[arg-type]  # CasADi stubs wrong
+                self._opti.set_initial(
+                    interval_dt, min(max(ts_final_guess / self.nodes, dt_min), dt_max)
+                )
+                self._interval_dts.append(interval_dt)
+            else:
+                interval_dt = self.dt
+
             # Control variable
             Uk = self._opti.variable(self.u.shape[0])
             U.append(Uk)
@@ -522,9 +561,9 @@ class Base:
                 for r in range(self.polydeg):
                     xpc = xpc + C[r + 1, j] * Xc[r]
 
-                fj, qj = self.func_dynamics(Xc[j - 1], Uk)  # type: ignore[misc]  # CasADi Function.__call__ return is opaque to pyright
+                fj, qj = self.func_dynamics(Xc[j - 1], Uk, interval_dt)  # type: ignore[misc]  # CasADi Function.__call__ return is opaque to pyright
                 self._constrain_performance_model_domain(fj)
-                self._opti.subject_to(self.dt * fj == xpc)
+                self._opti.subject_to(interval_dt * fj == xpc)
 
                 Xk_end = Xk_end + D[j] * Xc[j - 1]
                 J = J + B[j] * qj
@@ -543,6 +582,11 @@ class Base:
 
             # Continuity constraint
             self._opti.subject_to(Xk_end == Xk)
+
+        if variable_timestep:
+            self._opti.subject_to(
+                ca.sum1(ca.vertcat(*self._interval_dts)) == self.ts_final
+            )
 
         # Optional: rescale the objective by its value at the initial guess
         # so IPOPT sees f(x0) ≈ 1. Important for objectives whose natural
@@ -567,6 +611,75 @@ class Base:
         self._opti.minimize(J)
 
         return X, U
+
+    def _interval_dt(self, k: int) -> Any:
+        if getattr(self, "_variable_timestep", False):
+            return self._interval_dts[k]
+        return self.dt
+
+    def _normalize_waypoints(self, waypoints: Any = None) -> list[LatLon]:
+        if waypoints is None:
+            return []
+        normalized = []
+        for waypoint in waypoints:
+            if len(waypoint) != 2:
+                raise ValueError("waypoints must be (lat, lon) pairs")
+            lat, lon = float(waypoint[0]), float(waypoint[1])
+            if not -90 <= lat <= 90:
+                raise ValueError(f"waypoint latitude out of range: {lat}")
+            if not -180 <= lon <= 180:
+                raise ValueError(f"waypoint longitude out of range: {lon}")
+            normalized.append((lat, lon))
+        return normalized
+
+    def _waypoint_node_indices(
+        self, waypoints: list[LatLon], waypoint_node_indices: Any = None
+    ) -> list[int]:
+        if not waypoints:
+            return []
+        if len(waypoints) >= self.nodes:
+            raise ValueError("number of waypoints must be smaller than optimizer nodes")
+
+        if waypoint_node_indices is None:
+            return [
+                max(
+                    1,
+                    min(
+                        self.nodes - 1,
+                        round((i + 1) * self.nodes / (len(waypoints) + 1)),
+                    ),
+                )
+                for i in range(len(waypoints))
+            ]
+
+        indices = [int(index) for index in waypoint_node_indices]
+        if len(indices) != len(waypoints):
+            raise ValueError("waypoint_node_indices must match number of waypoints")
+        if any(index <= 0 or index >= self.nodes for index in indices):
+            raise ValueError("waypoint_node_indices must be interior node indices")
+        if any(b <= a for a, b in pairwise(indices)):
+            raise ValueError("waypoint_node_indices must be strictly increasing")
+        return indices
+
+    def _constrain_waypoints(
+        self,
+        X: list[Any],
+        waypoints: Any = None,
+        *,
+        waypoint_tolerance_m: float = 2_000.0,
+        waypoint_node_indices: Any = None,
+    ) -> None:
+        normalized = self._normalize_waypoints(waypoints)
+        if not normalized:
+            return
+        if waypoint_tolerance_m <= 0:
+            raise ValueError("waypoint_tolerance_m must be positive")
+
+        indices = self._waypoint_node_indices(normalized, waypoint_node_indices)
+        for index, (lat, lon) in zip(indices, normalized):
+            xp, yp = self.proj(lon, lat)
+            dist2 = (X[index][0] - xp) ** 2 + (X[index][1] - yp) ** 2
+            self._opti.subject_to(dist2 <= waypoint_tolerance_m**2)
 
     def _constrain_performance_model_domain(self, xdot: ca.MX) -> None:
         """Keep symbolic dynamics inside model-valid regions.

--- a/opentop/climb.py
+++ b/opentop/climb.py
@@ -70,7 +70,10 @@ class Climb(Base):
         )
 
     def init_conditions(
-        self, df_cruise: pd.DataFrame, alt_stop: float | None = None
+        self,
+        df_cruise: pd.DataFrame,
+        alt_stop: float | None = None,
+        waypoints: list[LatLon] | None = None,
     ) -> None:
         """Initialize direct collocation bounds and guesses.
 
@@ -81,7 +84,7 @@ class Climb(Base):
 
         # Convert lat/lon to Cartesian coordinates.
         xp_0, yp_0 = self.proj(self.lon1, self.lat1)
-        x_min, x_max, y_min, y_max = self._compute_bbox()
+        x_min, x_max, y_min, y_max = self._compute_bbox(waypoints=waypoints)
         od_psi = self._compute_bearing_psi()
 
         mass_0 = self.mass_init
@@ -153,6 +156,12 @@ class Climb(Base):
         time_dependent: bool = False,
         auto_rescale_objective: bool = False,
         exact_hessian: bool = False,
+        waypoints: list[LatLon] | None = None,
+        waypoint_tolerance_m: float = 2_000.0,
+        waypoint_node_indices: list[int] | None = None,
+        variable_timestep: bool | None = None,
+        dt_min: float = 5.0,
+        dt_max: float | None = None,
         result_object: bool = False,
     ) -> pd.DataFrame | TrajectoryResult:
         """Compute the optimal climb trajectory.
@@ -170,6 +179,14 @@ class Climb(Base):
             time_dependent: Grid cost is time-dependent. Default False.
             auto_rescale_objective: Rescale objective to O(1). Default False.
             exact_hessian: Force IPOPT exact Hessian. Default False.
+            waypoints: Ordered waypoint list as (lat, lon) pairs.
+            waypoint_tolerance_m: Maximum waypoint miss distance in meters.
+            waypoint_node_indices: Optional interior node indices assigned to
+                waypoints. Defaults to evenly spaced ordered interior nodes.
+            variable_timestep: Optimize interval durations. Defaults to True
+                when waypoints are supplied, otherwise False.
+            dt_min: Minimum interval duration in seconds for variable timesteps.
+            dt_max: Maximum interval duration in seconds for variable timesteps.
             result_object: If True, return a TrajectoryResult.
 
         Returns:
@@ -184,8 +201,6 @@ class Climb(Base):
             print("Calculating optimal climbing trajectory...")
 
         assert isinstance(df_cruise, pd.DataFrame)
-        self.init_conditions(df_cruise, alt_stop=alt_stop)
-
         _kwargs = {
             "initial_guess": initial_guess,
             "interpolant": interpolant,
@@ -193,7 +208,19 @@ class Climb(Base):
             "time_dependent": time_dependent,
             "auto_rescale_objective": auto_rescale_objective,
             "exact_hessian": exact_hessian,
+            "waypoints": waypoints,
+            "waypoint_tolerance_m": waypoint_tolerance_m,
+            "waypoint_node_indices": waypoint_node_indices,
+            "variable_timestep": waypoints is not None
+            if variable_timestep is None
+            else variable_timestep,
+            "dt_min": dt_min,
+            "dt_max": dt_max,
         }
+        if dt_max is None:
+            _kwargs.pop("dt_max")
+
+        self.init_conditions(df_cruise, alt_stop=alt_stop, waypoints=waypoints)
 
         X, U = self._build_opti(objective, ts_final_guess=3600, **_kwargs)
         opti = self._opti
@@ -210,8 +237,9 @@ class Climb(Base):
             hk1 = X[k + 1][2]
             vk = oc.aero.mach2tas(U[k][0], hk, dT=self.dT)
             vk1 = oc.aero.mach2tas(U[k + 1][0], hk1, dT=self.dT)
-            dvdt = (vk1 - vk) / self.dt
-            dhdt = (hk1 - hk) / self.dt
+            interval_dt = self._interval_dt(k)
+            dvdt = (vk1 - vk) / interval_dt
+            dhdt = (hk1 - hk) / interval_dt
             thrust_max = self._thrust_climb(vk / kts, hk / ft)
             drag = self.drag.clean(X[k][3], vk / kts, hk / ft, dT=self.dT)
             opti.subject_to(
@@ -220,7 +248,8 @@ class Climb(Base):
 
         # Constrain time and dt
         for k in range(1, self.nodes):
-            opti.subject_to(opti.bounded(-1, X[k][4] - X[k - 1][4] - self.dt, 1))  # type: ignore[arg-type]  # CasADi stubs wrong
+            time_delta = X[k][4] - X[k - 1][4] - self._interval_dt(k - 1)
+            opti.subject_to(opti.bounded(-1, time_delta, 1))  # type: ignore[arg-type]  # CasADi stubs wrong
 
         # Smooth vertical rate changes
         for k in range(1, self.nodes):
@@ -244,6 +273,13 @@ class Climb(Base):
         xp_0, yp_0 = self.proj(self.lon1, self.lat1)
         climb_range = ca.sqrt((X[-1][0] - xp_0) ** 2 + (X[-1][1] - yp_0) ** 2)
         opti.subject_to(climb_range == self.traj_range)
+
+        self._constrain_waypoints(
+            X,
+            waypoints,
+            waypoint_tolerance_m=waypoint_tolerance_m,
+            waypoint_node_indices=waypoint_node_indices,
+        )
 
         # --- Solve ---
         df = self._solve(X, U, **_kwargs)

--- a/opentop/cruise.py
+++ b/opentop/cruise.py
@@ -77,7 +77,9 @@ class Cruise(Base):
         # Convert lat/lon to Cartesian coordinates.
         xp_0, yp_0 = self.proj(self.lon1, self.lat1)
         xp_f, yp_f = self.proj(self.lon2, self.lat2)
-        x_min, x_max, y_min, y_max = self._compute_bbox()
+        x_min, x_max, y_min, y_max = self._compute_bbox(
+            waypoints=kwargs.get("waypoints")
+        )
 
         ts_min = 0
         ts_max = max(5, self.range / 1000 / 500) * 3600
@@ -143,6 +145,12 @@ class Cruise(Base):
         time_dependent: bool = False,
         auto_rescale_objective: bool = False,
         exact_hessian: bool = False,
+        waypoints: list[LatLon] | None = None,
+        waypoint_tolerance_m: float = 2_000.0,
+        waypoint_node_indices: list[int] | None = None,
+        variable_timestep: bool | None = None,
+        dt_min: float = 5.0,
+        dt_max: float | None = None,
         result_object: bool = False,
     ) -> pd.DataFrame | TrajectoryResult:
         """Compute the optimal cruise trajectory.
@@ -162,6 +170,14 @@ class Cruise(Base):
             time_dependent: Grid cost is time-dependent. Default False.
             auto_rescale_objective: Rescale objective to O(1). Default False.
             exact_hessian: Force IPOPT exact Hessian. Default False.
+            waypoints: Ordered waypoint list as (lat, lon) pairs.
+            waypoint_tolerance_m: Maximum waypoint miss distance in meters.
+            waypoint_node_indices: Optional interior node indices assigned to
+                waypoints. Defaults to evenly spaced ordered interior nodes.
+            variable_timestep: Optimize interval durations. Defaults to True
+                when waypoints are supplied, otherwise False.
+            dt_min: Minimum interval duration in seconds for variable timesteps.
+            dt_max: Maximum interval duration in seconds for variable timesteps.
             result_object: If True, return a TrajectoryResult instead of a
                 DataFrame. Default False.
 
@@ -175,7 +191,17 @@ class Cruise(Base):
             "time_dependent": time_dependent,
             "auto_rescale_objective": auto_rescale_objective,
             "exact_hessian": exact_hessian,
+            "waypoints": waypoints,
+            "waypoint_tolerance_m": waypoint_tolerance_m,
+            "waypoint_node_indices": waypoint_node_indices,
+            "variable_timestep": waypoints is not None
+            if variable_timestep is None
+            else variable_timestep,
+            "dt_min": dt_min,
+            "dt_max": dt_max,
         }
+        if dt_max is None:
+            _kwargs.pop("dt_max")
         init_kwargs = dict(_kwargs)
         if h_min is not None:
             init_kwargs["h_min"] = h_min
@@ -208,7 +234,10 @@ class Cruise(Base):
 
         # ts and dt consistency
         for k in range(self.nodes - 1):
-            opti.subject_to(opti.bounded(-1, X[k + 1][4] - X[k][4] - self.dt, 1))  # type: ignore[arg-type]  # CasADi stubs wrong: bounded(float, expr, float) is valid
+            opti.subject_to(
+                opti.bounded(-1, X[k + 1][4] - X[k][4] - self._interval_dt(k), 1)  # type: ignore[arg-type]
+                # CasADi stubs wrong: bounded(float, expr, float) is valid
+            )
 
         # Smooth heading change
         for k in range(self.nodes - 1):
@@ -238,6 +267,13 @@ class Cruise(Base):
         if not self.allow_descent:
             for k in range(self.nodes):
                 opti.subject_to(U[k][1] >= 0)
+
+        self._constrain_waypoints(
+            X,
+            waypoints,
+            waypoint_tolerance_m=waypoint_tolerance_m,
+            waypoint_node_indices=waypoint_node_indices,
+        )
 
         # Fuel constraint
         opti.subject_to(opti.bounded(0, X[0][3] - X[-1][3], self.fuel_max))  # type: ignore[arg-type]  # CasADi stubs wrong

--- a/opentop/descent.py
+++ b/opentop/descent.py
@@ -56,7 +56,10 @@ class Descent(Base):
         )
 
     def init_conditions(
-        self, df_cruise: pd.DataFrame, alt_start: float | None = None
+        self,
+        df_cruise: pd.DataFrame,
+        alt_start: float | None = None,
+        waypoints: list[LatLon] | None = None,
     ) -> None:
         """Initialize direct collocation bounds and guesses.
 
@@ -71,7 +74,7 @@ class Descent(Base):
         xp_0, yp_0 = self.proj(self.lon1, self.lat1)
         xp_f, yp_f = self.proj(self.lon2, self.lat2)
 
-        x_min, x_max, y_min, y_max = self._compute_bbox()
+        x_min, x_max, y_min, y_max = self._compute_bbox(waypoints=waypoints)
         ts_min = 0
         ts_max = 6 * 3600
 
@@ -141,6 +144,12 @@ class Descent(Base):
         time_dependent: bool = False,
         auto_rescale_objective: bool = False,
         exact_hessian: bool = False,
+        waypoints: list[LatLon] | None = None,
+        waypoint_tolerance_m: float = 2_000.0,
+        waypoint_node_indices: list[int] | None = None,
+        variable_timestep: bool | None = None,
+        dt_min: float = 5.0,
+        dt_max: float | None = None,
         result_object: bool = False,
     ) -> pd.DataFrame | TrajectoryResult:
         """Compute the optimal descent trajectory.
@@ -158,6 +167,14 @@ class Descent(Base):
             time_dependent: Grid cost is time-dependent. Default False.
             auto_rescale_objective: Rescale objective to O(1). Default False.
             exact_hessian: Force IPOPT exact Hessian. Default False.
+            waypoints: Ordered waypoint list as (lat, lon) pairs.
+            waypoint_tolerance_m: Maximum waypoint miss distance in meters.
+            waypoint_node_indices: Optional interior node indices assigned to
+                waypoints. Defaults to evenly spaced ordered interior nodes.
+            variable_timestep: Optimize interval durations. Defaults to True
+                when waypoints are supplied, otherwise False.
+            dt_min: Minimum interval duration in seconds for variable timesteps.
+            dt_max: Maximum interval duration in seconds for variable timesteps.
             result_object: If True, return a TrajectoryResult.
 
         Returns:
@@ -172,7 +189,6 @@ class Descent(Base):
             print("Calculating optimal descent trajectory...")
 
         assert isinstance(df_cruise, pd.DataFrame)
-        self.init_conditions(df_cruise, alt_start=alt_start)
 
         _kwargs = {
             "initial_guess": initial_guess,
@@ -181,7 +197,19 @@ class Descent(Base):
             "time_dependent": time_dependent,
             "auto_rescale_objective": auto_rescale_objective,
             "exact_hessian": exact_hessian,
+            "waypoints": waypoints,
+            "waypoint_tolerance_m": waypoint_tolerance_m,
+            "waypoint_node_indices": waypoint_node_indices,
+            "variable_timestep": waypoints is not None
+            if variable_timestep is None
+            else variable_timestep,
+            "dt_min": dt_min,
+            "dt_max": dt_max,
         }
+        if dt_max is None:
+            _kwargs.pop("dt_max")
+
+        self.init_conditions(df_cruise, alt_start=alt_start, waypoints=waypoints)
 
         X, U = self._build_opti(objective, ts_final_guess=3600, **_kwargs)
         opti = self._opti
@@ -190,7 +218,8 @@ class Descent(Base):
 
         # Constrain time and dt
         for k in range(1, self.nodes):
-            opti.subject_to(opti.bounded(-1, X[k][4] - X[k - 1][4] - self.dt, 1))  # type: ignore[arg-type]  # CasADi stubs wrong: bounded(float, expr, float) is valid
+            time_delta = X[k][4] - X[k - 1][4] - self._interval_dt(k - 1)
+            opti.subject_to(opti.bounded(-1, time_delta, 1))  # type: ignore[arg-type]  # CasADi stubs wrong
 
         # Smooth Mach number changes
         for k in range(1, self.nodes):
@@ -220,6 +249,13 @@ class Descent(Base):
             # Excess energy > change in potential energy
             excess_energy = (thrust_max - drag) * v - mass * oc.aero.g0 * U[k][1]
             opti.subject_to(excess_energy >= 0)
+
+        self._constrain_waypoints(
+            X,
+            waypoints,
+            waypoint_tolerance_m=waypoint_tolerance_m,
+            waypoint_node_indices=waypoint_node_indices,
+        )
 
         # --- Solve ---
         df = self._solve(X, U, **_kwargs)

--- a/opentop/full.py
+++ b/opentop/full.py
@@ -53,7 +53,9 @@ class CompleteFlight(Base):
         # Convert lat/lon to Cartesian coordinates.
         xp_0, yp_0 = self.proj(self.lon1, self.lat1)
         xp_f, yp_f = self.proj(self.lon2, self.lat2)
-        x_min, x_max, y_min, y_max = self._compute_bbox()
+        x_min, x_max, y_min, y_max = self._compute_bbox(
+            waypoints=kwargs.get("waypoints")
+        )
 
         ts_min = 0
         ts_max = max(5, self.range / 1000 / 500) * 3600
@@ -126,6 +128,12 @@ class CompleteFlight(Base):
         time_dependent: bool = False,
         auto_rescale_objective: bool = False,
         exact_hessian: bool = False,
+        waypoints: list[LatLon] | None = None,
+        waypoint_tolerance_m: float = 2_000.0,
+        waypoint_node_indices: list[int] | None = None,
+        variable_timestep: bool | None = None,
+        dt_min: float = 5.0,
+        dt_max: float | None = None,
         result_object: bool = False,
     ) -> pd.DataFrame | TrajectoryResult:
         """Compute the optimal complete flight trajectory.
@@ -142,6 +150,14 @@ class CompleteFlight(Base):
             time_dependent: Grid cost is time-dependent. Default False.
             auto_rescale_objective: Rescale objective to O(1). Default False.
             exact_hessian: Force IPOPT exact Hessian. Default False.
+            waypoints: Ordered waypoint list as (lat, lon) pairs.
+            waypoint_tolerance_m: Maximum waypoint miss distance in meters.
+            waypoint_node_indices: Optional interior node indices assigned to
+                waypoints. Defaults to evenly spaced ordered interior nodes.
+            variable_timestep: Optimize interval durations. Defaults to True
+                when waypoints are supplied, otherwise False.
+            dt_min: Minimum interval duration in seconds for variable timesteps.
+            dt_max: Maximum interval duration in seconds for variable timesteps.
             result_object: If True, return a TrajectoryResult.
 
         Returns:
@@ -154,7 +170,17 @@ class CompleteFlight(Base):
             "time_dependent": time_dependent,
             "auto_rescale_objective": auto_rescale_objective,
             "exact_hessian": exact_hessian,
+            "waypoints": waypoints,
+            "waypoint_tolerance_m": waypoint_tolerance_m,
+            "waypoint_node_indices": waypoint_node_indices,
+            "variable_timestep": waypoints is not None
+            if variable_timestep is None
+            else variable_timestep,
+            "dt_min": dt_min,
+            "dt_max": dt_max,
         }
+        if dt_max is None:
+            _kwargs.pop("dt_max")
         self.init_conditions(**_kwargs)
 
         if initial_guess is not None:
@@ -208,7 +234,10 @@ class CompleteFlight(Base):
 
         # ts and dt consistency
         for k in range(self.nodes - 1):
-            opti.subject_to(opti.bounded(-1, X[k + 1][4] - X[k][4] - self.dt, 1))  # type: ignore[arg-type]  # CasADi stubs wrong
+            opti.subject_to(
+                opti.bounded(-1, X[k + 1][4] - X[k][4] - self._interval_dt(k), 1)  # type: ignore[arg-type]
+                # CasADi stubs wrong
+            )
 
         # Smooth Mach number change
         mach_change_limit = self._mach_change_limit()
@@ -230,6 +259,13 @@ class CompleteFlight(Base):
 
         # Fuel constraint
         opti.subject_to(opti.bounded(0, X[0][3] - X[-1][3], self.fuel_max))  # type: ignore[arg-type]  # CasADi stubs wrong
+
+        self._constrain_waypoints(
+            X,
+            waypoints,
+            waypoint_tolerance_m=waypoint_tolerance_m,
+            waypoint_node_indices=waypoint_node_indices,
+        )
 
         if customized_max_fuel is not None:
             opti.subject_to(X[0][3] - X[-1][3] <= customized_max_fuel)

--- a/tests/test_waypoints.py
+++ b/tests/test_waypoints.py
@@ -1,0 +1,83 @@
+"""Tests for waypoint-constrained trajectories."""
+
+import openap
+import pytest
+
+import opentop as top
+import pandas as pd
+
+
+def _midpoint_waypoint(opt):
+    xp_0, yp_0 = opt.proj(opt.lon1, opt.lat1)
+    xp_f, yp_f = opt.proj(opt.lon2, opt.lat2)
+    lon, lat = opt.proj((xp_0 + xp_f) / 2, (yp_0 + yp_f) / 2, inverse=True)
+    return lat, lon
+
+
+def test_cruise_waypoint_solution_passes_near_waypoint(aircraft_type, short_flight):
+    opt = top.Cruise(
+        aircraft_type,
+        short_flight["origin"],
+        short_flight["destination"],
+        short_flight["m0"],
+    )
+    waypoint = _midpoint_waypoint(opt)
+
+    df = opt.trajectory(
+        objective="fuel",
+        waypoints=[waypoint],
+        waypoint_tolerance_m=10_000,
+    )
+    assert isinstance(df, pd.DataFrame)
+
+    distances = [
+        openap.aero.distance(lat, lon, waypoint[0], waypoint[1])
+        for lat, lon in zip(df.latitude, df.longitude)
+    ]
+    assert min(distances) <= 10_500
+    assert df.ts.diff().dropna().gt(0).all()
+
+
+def test_waypoint_variable_timestep_supports_time_objective(
+    monkeypatch, aircraft_type, short_flight
+):
+    opt = top.Cruise(
+        aircraft_type,
+        short_flight["origin"],
+        short_flight["destination"],
+        short_flight["m0"],
+    )
+    waypoint = _midpoint_waypoint(opt)
+
+    class FakeSolution:
+        def stats(self):
+            return {"success": True}
+
+    def fake_solve(X, U, **kwargs):
+        opt._last_solution = FakeSolution()
+        return pd.DataFrame(
+            {
+                "altitude": [30_000.0, 30_000.0],
+                "mass": [opt.mass_init, opt.mass_init - 1.0],
+            }
+        )
+
+    monkeypatch.setattr(opt, "_solve", fake_solve)
+
+    df = opt.trajectory(objective="time", waypoints=[waypoint])
+
+    assert df is not None
+    assert opt._variable_timestep is True
+    assert len(opt._interval_dts) == opt.nodes
+
+
+def test_waypoint_latitude_is_validated(aircraft_type, short_flight):
+    opt = top.Cruise(
+        aircraft_type,
+        short_flight["origin"],
+        short_flight["destination"],
+        short_flight["m0"],
+    )
+
+    with pytest.raises(ValueError, match="latitude"):
+        opt.trajectory(objective="fuel", waypoints=[(95.0, 0.0)])


### PR DESCRIPTION
## Summary
- add ordered waypoint constraints for phase trajectory APIs
- support optional variable interval durations so waypoint-constrained solves can adapt timing
- use solved timestamp states in trajectory export for variable-step trajectories
- add waypoint tests and an example that loads real fixes from OpenAP nav data (`ARNEM`, `KENUM`, `DODEN`, `BOMBI`)

Supersedes the waypoint implementation approach in #22 with a fresh implementation on current `main`.

## Tests
- `uv run pytest --collect-only -q`
- `uv run pytest tests/test_waypoints.py -n auto -q`
- `uv run pytest tests/test_climb.py tests/test_descent.py tests/test_trajectory_costs.py tests/test_waypoints.py -n auto -q`
- `uv run pytest tests/test_cruise.py tests/test_full_flight.py tests/test_trajectory_export.py tests/test_waypoints.py -n auto -q`
- `uv run pytest tests/ -n auto -q -k 'not bada'`\n- `uv run ruff check .`\n- `uv run pyright`\n- `uv run python examples/waypoints.py`\n\nFull `uv run pytest tests/ -n auto -q` was also attempted locally: non-BADA tests passed, but 8 optional BADA tests failed inside OpenAP BADA addon objects (`sci` / `clean_drag_polar_params` attributes) because local BADA data paths are present on this machine.